### PR TITLE
Correction d'un bug sur le nom du package à charger

### DIFF
--- a/doc/ipsum-doc.tex
+++ b/doc/ipsum-doc.tex
@@ -140,7 +140,7 @@ To load the package, simply use :
 
 \begin{quote}
 \begin{verbatim}
-\usepackage{blindtext}
+\usepackage{ipsum}
 \end{verbatim}
 \end{quote}
 


### PR DESCRIPTION
Le nom du package étant « ipsum », je pense que c'est bien ce package qui est à charger.